### PR TITLE
Update Ubuntu command

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Developed this library on [Novation Launchpad Mini](https://novationmusic.com/la
 ### Linux (Ubuntu)
 
 ```bash
-$ apt-get install libportmidi0
+$ apt-get install libportmidi-dev
 ```
 
 ### Mac OS


### PR DESCRIPTION
On Ubuntu 20.04 LTS, installing libportmidi0 resulted in not being able to start my dotnet application that referenced the Launchpad project. After installing the package libportmidi-dev, the application was able to start.